### PR TITLE
Migrate config to use trapperkeeper-webserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Here is an example of how a Trapperkeeper service can use the
 ~~~~
 
 See the
-[Trapperkeeper web service](https://github.com/openvoxproject/trapperkeeper-webserver-jetty10)
+[Trapperkeeper web service](https://github.com/openvoxproject/trapperkeeper-webserver)
 project for more information on the `:WebserverService`.
 
 For this example, if the web server receives a request to the "/hello"

--- a/examples/ring_app/README.md
+++ b/examples/ring_app/README.md
@@ -2,9 +2,9 @@
 
 This example demonstrates how to incorporate the trapperkeeper-authorization
 service into a simple Ring app.  This is based loosely upon the
-[ring_app example] (https://github.com/openvoxproject/trapperkeeper-webserver-jetty10/tree/master/examples/ring_app)
-in the trapperkeeper-webserver-jetty10 project.  See that example for more
-information on the use of the `jetty10-service` and the Jetty web server
+[ring_app example] (https://github.com/openvoxproject/trapperkeeper-webserver/tree/master/examples/ring_app)
+in the trapperkeeper-webserver project.  See that example for more
+information on the use of the `jetty-service` and the Jetty web server
 integration with Ring.
 
 This example includes a simple set of default authorization rules which can be
@@ -39,12 +39,12 @@ namespaces and service names. For this example, the bootstrap.cfg looks like
 this:
 
 ~~~~
-puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
+puppetlabs.trapperkeeper.services.webserver.jetty-service/jetty-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 examples.ring-app.ring-app/hello-service
 ~~~~
 
-This configuration indicates that the jetty10 `WebserverService`, authorization
+This configuration indicates that the jetty `WebserverService`, authorization
 service, and new "hello" service, defined in the `ring_app.clj` file, are to be
 loaded.
 

--- a/examples/ring_app/bootstrap.cfg
+++ b/examples/ring_app/bootstrap.cfg
@@ -1,3 +1,3 @@
-puppetlabs.trapperkeeper.services.webserver.jetty10-service/jetty10-service
+puppetlabs.trapperkeeper.services.webserver.jetty-service/jetty-service
 puppetlabs.trapperkeeper.services.authorization.authorization-service/authorization-service
 examples.ring-app.ring-app/hello-service

--- a/examples/ring_app/src/examples/ring_app/repl.clj
+++ b/examples/ring_app/src/examples/ring_app/repl.clj
@@ -7,8 +7,8 @@
     [puppetlabs.trapperkeeper.core :as tk]
     [puppetlabs.trapperkeeper.services.authorization.authorization-service
      :refer [authorization-service]]
-    [puppetlabs.trapperkeeper.services.webserver.jetty10-service
-     :refer [jetty10-service]]))
+    [puppetlabs.trapperkeeper.services.webserver.jetty-service
+     :refer [jetty-service]]))
 
 ;; This namespace shows an example of the "reloaded" clojure workflow
 ;; ( http://thinkrelevance.com/blog/2013/06/04/clojure-workflow-reloaded )
@@ -31,7 +31,7 @@
 (defn init []
   (alter-var-root #'system
                   (fn [_] (tk/build-app
-                           [jetty10-service
+                           [jetty-service
                             authorization-service
                             hello-service]
                            {:global

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
 (def trapperkeeper-version "4.3.2")
 (def i18n-version "1.0.4")
 
-(defproject org.openvoxproject/trapperkeeper-authorization "2.1.11-SNAPSHOT"
+(defproject org.openvoxproject/trapperkeeper-authorization "2.2.0-SNAPSHOT"
   :description "Trapperkeeper authorization system"
   :url "http://github.com/openvoxproject/trapperkeeper-authorization"
   :license {:name "Apache License, Version 2.0"
@@ -36,7 +36,7 @@
                          [org.openvoxproject/ssl-utils "3.6.4"]
                          [org.openvoxproject/trapperkeeper "4.3.5"]
                          [org.openvoxproject/trapperkeeper "4.3.5" :classifier "test"]
-                         [org.openvoxproject/trapperkeeper-webserver-jetty10 "1.1.8"]
+                         [org.openvoxproject/trapperkeeper-webserver "10.0.0"]
                          [prismatic/schema "1.4.1"]
                          [ring/ring-codec "1.3.0"]
                          [ring/ring-core "1.14.2"]
@@ -66,7 +66,7 @@
                               "-b" "./examples/ring_app/bootstrap.cfg"
                               "-c" "./examples/ring_app/ring-example.conf"]}
                    :source-paths ["examples/ring_app/src"]
-                   :dependencies [[org.openvoxproject/trapperkeeper-webserver-jetty10]
+                   :dependencies [[org.openvoxproject/trapperkeeper-webserver]
                                   [org.openvoxproject/trapperkeeper :classifier "test" :scope "test"]
                                   [org.openvoxproject/kitchensink :classifier "test" :scope "test"]
                                   [org.clojure/tools.namespace]


### PR DESCRIPTION
We removed the 'Jetty10' from the repo and component name, as well as classes and service names.

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md) document
- [ ] read and accepted the [Developer Certificate of Origin](https://github.com/OpenVoxProject/.github/blob/main/DCO.md) document and added a [`Signed-off-by`](https://github.com/OpenVoxProject/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin) annotation to each of my commits
- [ ] tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
